### PR TITLE
Add gitleaks repo scan and submit github security scanning alert

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [gitleaks]
     if: always() && (needs.gitleaks.result == 'failure')
-    permissions: 
+    permissions:
       security-events: write
     steps:
     - name: Check out the repo
@@ -31,6 +31,4 @@ jobs:
         # Path to SARIF file relative to the root of the repository
         sarif_file: result.sarif
         # Optional category for the results
-        category: secret-analysis        
-
-  
+        category: secret-analysis

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,36 @@
+name: Gitleaks
+
+on: [pull_request, push, workflow_dispatch]
+
+jobs:
+  gitleaks:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+          - name: Check out the repo
+            uses: actions/checkout@v2
+          - name: Run gitleaks
+            run: docker run -v ${{ github.workspace }}:/path zricethezav/gitleaks:latest detect -v --source="/path"  --redact
+
+  run-if-failed:
+    name: Github Security Report (if gitleaks job fails)
+    runs-on: ubuntu-latest
+    needs: [gitleaks]
+    if: always() && (needs.gitleaks.result == 'failure')
+    permissions: 
+      security-events: write
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v2
+    - name: Generate gitleaks SARIF file
+      # Exit 0 so we can get the failed report results from this step.
+      run:  docker run -v ${{ github.workspace }}:/path zricethezav/gitleaks:latest detect -v --source="/path"  --redact --report-format sarif --report-path="/path/result.sarif" --exit-code=0
+    - name: Upload SARIF file
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        # Path to SARIF file relative to the root of the repository
+        sarif_file: result.sarif
+        # Optional category for the results
+        category: secret-analysis        
+
+  


### PR DESCRIPTION
### Change
Contains the github workflow to:

1. Run gitleaks secret scanning on repo
2. On detection, submit Github security alert

Closes #3 .

### Considerations

GH actions for gitleaks requires licensing for organization repositories as per https://github.com/marketplace/actions/gitleaks#do-i-need-a-license-key therefore this has been somewhat hand crafted.

### Sample results

Can be viewed here https://github.com/haani-niyaz/gitleaks-gh-action-sample/actions/runs/2532666777 

![Screen Shot 2022-06-21 at 6 32 23 pm](https://user-images.githubusercontent.com/5335941/174754710-e328e8bf-5eb9-4913-a08f-de6ae9ff5e25.png)

Security alert can be viewed from Security (tab) -> Code scanning alerts (menu option).

