### PR TITLE
Add initial  dependabot setup

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5


### PR DESCRIPTION

Closes #5, using the bare setup that can be updated as needed. 