### PR TITLE
Add gitleaks to detect secrets on commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,10 @@ repos:
     rev: v1.46.2
     hooks:
       - id: golangci-lint
+  - repo: https://github.com/zricethezav/gitleaks
+    rev: v8.2.0
+    hooks:
+      - id: gitleaks
 
 ci:
   autofix_commit_msg: |


### PR DESCRIPTION
Although we have secret scanning in our CI, if secrets are found it is already too late as the secrets have been committed to the repo. Instead add a pre-commit to shift left and detect early.

