### PR TITLE
Update golangci-lint version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,14 +10,14 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run linters
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          version: v1.47.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir


### PR DESCRIPTION
It looks like golangci-lint works for the 1.18 version now.
Proposing to update it in order to support 'any' and other 1.18 features.
(tried this update on the https://github.com/rog-golang-buddies/api-hub_data-scraping-service/runs/7590078640?check_suite_focus=true cause it failed because of 'any')